### PR TITLE
Avoid duplicate release gate runs

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -3,8 +3,6 @@ name: CamAdmiral release gate
 on:
   workflow_call:
   pull_request:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What changed

Removed the standalone `push` trigger for `main` from the reusable release-gate workflow.

## Why

Merging a pull request and then tagging the same commit started two full release gates: one for the `main` push and another inside the tagged publish workflow. They were isolated but duplicated runner usage without adding release coverage.

Pull requests still run the full gate, tagged publishes still invoke the full gate before building, and manual dispatch remains available.

## Impact

Future releases run one tagged release gate instead of two gates for the same commit. There is no application or public contract change.

## Validation

- `git diff --check`
- Confirmed `.github/workflows/release.yml` still calls `.github/workflows/release-gate.yml`
