### PR TITLE
Document shared camera connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ downstream streams for consumers such as Frigate.
 - **Stable camera URLs.** Cameras on a local network can receive new IP addresses.
   CamAdmiral tracks adopted cameras by MAC and ONVIF identity and keeps their downstream
   URLs stable, so consumers do not need reconfiguration after an IP change.
+- **Shared camera connections.** While a stream is in use, CamAdmiral shares one upstream
+  connection to that camera stream across all downstream consumers. This reduces Wi-Fi
+  traffic and avoids exhausting cameras that support only a small number of simultaneous
+  clients.
 - **Health monitoring and alerts.** CamAdmiral monitors video availability, retains an
   availability history, and sends Telegram notifications when a camera goes offline or
   recovers.


### PR DESCRIPTION
## Summary
- add shared upstream connections as a core CamAdmiral benefit
- clarify that one connection is shared per camera stream while in use
- explain the Wi-Fi bandwidth and camera client-limit benefits

## Validation
- git diff --check