### PR TITLE
Discover cameras on oversized subnets without address sweeps

### DIFF
--- a/camadmiral/discovery.py
+++ b/camadmiral/discovery.py
@@ -32,6 +32,14 @@ MAX_SCAN_LOG_LINES = 5000
 VIRTUAL_INTERFACE_PREFIXES = ("docker", "veth", "br-", "virbr", "tailscale", "tun", "tap")
 
 
+def sweep_allowed(network: ipaddress.IPv4Network) -> bool:
+    """Whether per-address sweeps (unicast ONVIF, RTSP ports) fit the safety limit.
+
+    Multicast ONVIF discovery is independent of subnet size and always runs.
+    """
+    return max(0, network.num_addresses - 2) <= MAX_SCAN_HOSTS
+
+
 class DiscoveryScanError(RuntimeError):
     def __init__(self, message: str, raw_log: list[str]):
         super().__init__(message)
@@ -160,7 +168,6 @@ def private_lan_interfaces(
     except OSError:
         default_address = None
     eligible: list[LanInterface] = []
-    rejected_large: list[LanInterface] = []
     for interface in found:
         if interface.name == "lo" or interface.name.startswith(VIRTUAL_INTERFACE_PREFIXES):
             continue
@@ -171,9 +178,6 @@ def private_lan_interfaces(
             or interface.address.is_multicast
             or interface.address.is_unspecified
         ):
-            continue
-        if max(0, interface.network.num_addresses - 2) > MAX_SCAN_HOSTS:
-            rejected_large.append(interface)
             continue
         eligible.append(interface)
     eligible.sort(
@@ -194,12 +198,6 @@ def private_lan_interfaces(
         deduplicated.append(interface)
     if deduplicated:
         return deduplicated
-    if rejected_large:
-        interface = rejected_large[0]
-        hosts = max(0, interface.network.num_addresses - 2)
-        raise RuntimeError(
-            f"LAN subnet {interface.network} has {hosts} hosts; safety limit is {MAX_SCAN_HOSTS}"
-        )
     raise RuntimeError("No eligible private IPv4 LAN found")
 
 
@@ -352,10 +350,16 @@ def discover_onvif(
             sock.sendto(message, ONVIF_MULTICAST)
             emit(f"ONVIF: sent multicast probe {index}/{len(messages)} ({len(message)} bytes)")
         # A bounded unicast probe helps cameras with broken or disabled multicast.
-        for host in interface.network.hosts():
-            if host != interface.address:
-                sock.sendto(messages[0], (str(host), ONVIF_MULTICAST[1]))
-                emit(f"ONVIF: sent unicast probe to {host}:{ONVIF_MULTICAST[1]}")
+        if sweep_allowed(interface.network):
+            for host in interface.network.hosts():
+                if host != interface.address:
+                    sock.sendto(messages[0], (str(host), ONVIF_MULTICAST[1]))
+                    emit(f"ONVIF: sent unicast probe to {host}:{ONVIF_MULTICAST[1]}")
+        else:
+            emit(
+                f"ONVIF: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
+                "sweep limit; relying on multicast only, unicast fallback skipped"
+            )
         deadline = time.monotonic() + ONVIF_TIMEOUT
         while True:
             remaining = deadline - time.monotonic()
@@ -466,6 +470,12 @@ def discover_rtsp(
     log: Callable[[str], None] | None = None,
 ) -> list[dict[str, Any]]:
     emit = log or (lambda _message: None)
+    if not sweep_allowed(interface.network):
+        emit(
+            f"RTSP: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
+            "sweep limit; RTSP port sweep skipped"
+        )
+        return []
     targets = [str(host) for host in interface.network.hosts() if host != interface.address]
     emit(
         f"RTSP: probing {len(targets)} host(s), ports "
@@ -828,11 +838,22 @@ def scan_lan(
         )
     log(f"SCAN: start; networks={len(interfaces)}")
     known_devices = list(known_devices)
-    scanners = {"onvif": "running", "rtsp": "running", "reachability": "running"}
+    sweepable = [interface for interface in interfaces if sweep_allowed(interface.network)]
+    for interface in interfaces:
+        if interface not in sweepable:
+            log(
+                f"SCAN: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
+                "sweep limit; RTSP port sweep skipped, ONVIF multicast only"
+            )
+    scanners = {
+        "onvif": "running",
+        "rtsp": "running" if sweepable else "skipped",
+        "reachability": "running",
+    }
     errors: dict[str, str] = {}
     if progress:
-        for scanner in scanners:
-            progress(scanner, "running", primary_interface)
+        for scanner, state in scanners.items():
+            progress(scanner, state, primary_interface)
     results: dict[str, Any] = {"onvif": [], "rtsp": [], "reachability": []}
     scanner_failures: dict[str, list[str]] = defaultdict(list)
     scanner_successes: Counter[str] = Counter()
@@ -840,7 +861,8 @@ def scan_lan(
         futures: dict[concurrent.futures.Future[Any], tuple[str, LanInterface]] = {}
         for interface in interfaces:
             futures[pool.submit(discover_onvif, interface, log)] = ("onvif", interface)
-            futures[pool.submit(discover_rtsp, interface, log)] = ("rtsp", interface)
+            if interface in sweepable:
+                futures[pool.submit(discover_rtsp, interface, log)] = ("rtsp", interface)
             futures[
                 pool.submit(discover_reachable_known, interface, known_devices, log)
             ] = ("reachability", interface)
@@ -859,16 +881,18 @@ def scan_lan(
             else:
                 scanner_successes[scanner] += 1
     for scanner in scanners:
-        if scanner_successes[scanner]:
+        if scanners[scanner] == "skipped":
+            pass
+        elif scanner_successes[scanner]:
             scanners[scanner] = "complete"
         else:
             scanners[scanner] = "error"
             errors[scanner] = "; ".join(scanner_failures[scanner])[:200]
         if progress:
             progress(scanner, scanners[scanner], primary_interface)
-    if "onvif" in errors and "rtsp" in errors:
-        log("SCAN: failed; ONVIF and RTSP discovery both failed")
-        raise DiscoveryScanError("ONVIF and RTSP discovery both failed", raw_log)
+    if "onvif" in errors and scanners["rtsp"] != "complete":
+        log("SCAN: failed; ONVIF discovery failed and no RTSP sweep completed")
+        raise DiscoveryScanError("ONVIF discovery failed and no RTSP sweep completed", raw_log)
     onvif_devices = results["onvif"]
     rtsp_devices = results["rtsp"]
     arp_entries = read_arp_table()

--- a/camadmiral/discovery.py
+++ b/camadmiral/discovery.py
@@ -40,6 +40,29 @@ def sweep_allowed(network: ipaddress.IPv4Network) -> bool:
     return max(0, network.num_addresses - 2) <= MAX_SCAN_HOSTS
 
 
+def learned_neighbor_addresses(
+    interface: LanInterface,
+    arp_entries: dict[str, str],
+) -> list[str]:
+    """Return a bounded list of already-learned IPv4 neighbors on a LAN."""
+    return _bounded_interface_addresses(interface, arp_entries)
+
+
+def _bounded_interface_addresses(
+    interface: LanInterface,
+    candidate_addresses: Iterable[str],
+) -> list[str]:
+    addresses: list[ipaddress.IPv4Address] = []
+    for address in candidate_addresses:
+        try:
+            parsed = ipaddress.IPv4Address(address)
+        except ValueError:
+            continue
+        if parsed in interface.network and parsed != interface.address:
+            addresses.append(parsed)
+    return [str(address) for address in sorted(set(addresses))[:MAX_SCAN_HOSTS]]
+
+
 class DiscoveryScanError(RuntimeError):
     def __init__(self, message: str, raw_log: list[str]):
         super().__init__(message)
@@ -334,6 +357,7 @@ def parse_probe_matches(payload: bytes, sender_ip: str) -> list[dict[str, Any]]:
 def discover_onvif(
     interface: LanInterface,
     log: Callable[[str], None] | None = None,
+    fallback_addresses: Iterable[str] = (),
 ) -> list[dict[str, Any]]:
     discovered: dict[str, dict[str, Any]] = {}
     emit = log or (lambda _message: None)
@@ -351,15 +375,19 @@ def discover_onvif(
             emit(f"ONVIF: sent multicast probe {index}/{len(messages)} ({len(message)} bytes)")
         # A bounded unicast probe helps cameras with broken or disabled multicast.
         if sweep_allowed(interface.network):
-            for host in interface.network.hosts():
-                if host != interface.address:
-                    sock.sendto(messages[0], (str(host), ONVIF_MULTICAST[1]))
-                    emit(f"ONVIF: sent unicast probe to {host}:{ONVIF_MULTICAST[1]}")
+            unicast_targets = [
+                str(host) for host in interface.network.hosts() if host != interface.address
+            ]
         else:
+            unicast_targets = _bounded_interface_addresses(interface, fallback_addresses)
             emit(
                 f"ONVIF: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
-                "sweep limit; relying on multicast only, unicast fallback skipped"
+                f"sweep limit; using {len(unicast_targets)} learned neighbor(s) "
+                "for unicast fallback"
             )
+        for target in unicast_targets:
+            sock.sendto(messages[0], (target, ONVIF_MULTICAST[1]))
+            emit(f"ONVIF: sent unicast probe to {target}:{ONVIF_MULTICAST[1]}")
         deadline = time.monotonic() + ONVIF_TIMEOUT
         while True:
             remaining = deadline - time.monotonic()
@@ -477,6 +505,27 @@ def discover_rtsp(
         )
         return []
     targets = [str(host) for host in interface.network.hosts() if host != interface.address]
+    return _discover_rtsp_targets(targets, emit)
+
+
+def discover_rtsp_neighbors(
+    interface: LanInterface,
+    addresses: Iterable[str],
+    log: Callable[[str], None] | None = None,
+) -> list[dict[str, Any]]:
+    emit = log or (lambda _message: None)
+    targets = _bounded_interface_addresses(interface, addresses)
+    emit(
+        f"RTSP: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
+        f"sweep limit; probing {len(targets)} learned neighbor(s) only"
+    )
+    return _discover_rtsp_targets(targets, emit)
+
+
+def _discover_rtsp_targets(
+    targets: list[str],
+    emit: Callable[[str], None],
+) -> list[dict[str, Any]]:
     emit(
         f"RTSP: probing {len(targets)} host(s), ports "
         f"{', '.join(str(port) for port in RTSP_PORTS)}, {RTSP_WORKERS} workers, "
@@ -838,16 +887,27 @@ def scan_lan(
         )
     log(f"SCAN: start; networks={len(interfaces)}")
     known_devices = list(known_devices)
+    initial_arp_entries = read_arp_table()
     sweepable = [interface for interface in interfaces if sweep_allowed(interface.network)]
+    learned_neighbors = {
+        interface: learned_neighbor_addresses(interface, initial_arp_entries)
+        for interface in interfaces
+        if interface not in sweepable
+    }
+    rtsp_candidate_interfaces = [
+        interface for interface, addresses in learned_neighbors.items() if addresses
+    ]
     for interface in interfaces:
         if interface not in sweepable:
+            candidate_count = len(learned_neighbors[interface])
             log(
                 f"SCAN: subnet {interface.network} exceeds the {MAX_SCAN_HOSTS}-host "
-                "sweep limit; RTSP port sweep skipped, ONVIF multicast only"
+                f"sweep limit; ONVIF multicast plus {candidate_count} learned "
+                "neighbor candidate(s)"
             )
     scanners = {
         "onvif": "running",
-        "rtsp": "running" if sweepable else "skipped",
+        "rtsp": "running" if sweepable or rtsp_candidate_interfaces else "skipped",
         "reachability": "running",
     }
     errors: dict[str, str] = {}
@@ -860,9 +920,21 @@ def scan_lan(
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(interfaces) * 3) as pool:
         futures: dict[concurrent.futures.Future[Any], tuple[str, LanInterface]] = {}
         for interface in interfaces:
-            futures[pool.submit(discover_onvif, interface, log)] = ("onvif", interface)
+            neighbor_addresses = learned_neighbors.get(interface, [])
+            futures[
+                pool.submit(discover_onvif, interface, log, neighbor_addresses)
+            ] = ("onvif", interface)
             if interface in sweepable:
                 futures[pool.submit(discover_rtsp, interface, log)] = ("rtsp", interface)
+            elif neighbor_addresses:
+                futures[
+                    pool.submit(
+                        discover_rtsp_neighbors,
+                        interface,
+                        neighbor_addresses,
+                        log,
+                    )
+                ] = ("rtsp", interface)
             futures[
                 pool.submit(discover_reachable_known, interface, known_devices, log)
             ] = ("reachability", interface)
@@ -895,6 +967,7 @@ def scan_lan(
         raise DiscoveryScanError("ONVIF discovery failed and no RTSP sweep completed", raw_log)
     onvif_devices = results["onvif"]
     rtsp_devices = results["rtsp"]
+    # Reachability checks can populate or refresh ARP while scanners run.
     arp_entries = read_arp_table()
     known_by_ip = {str(device.get("ip") or ""): device for device in known_devices}
     reachable_known: list[str] = []

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,8 +7,8 @@ CamAdmiral application modules.
 The isolated Docker Compose lab covers:
 
 - manual and full RTSP discovery on a non-default connected private subnet
-- multicast-only ONVIF discovery on an oversized /16 subnet with per-address
-  ONVIF and RTSP sweeps skipped by the safety limit
+- multicast ONVIF discovery plus bounded learned-neighbor ONVIF and RTSP
+  probing on an oversized /16 subnet without a per-address sweep
 - explicit IP discovery and adoption through a synthetic ONVIF camera
 - unauthenticated and authenticated RTSP adoption
 - incorrect camera-credential rejection

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,8 @@ CamAdmiral application modules.
 The isolated Docker Compose lab covers:
 
 - manual and full RTSP discovery on a non-default connected private subnet
+- multicast-only ONVIF discovery on an oversized /16 subnet with per-address
+  ONVIF and RTSP sweeps skipped by the safety limit
 - explicit IP discovery and adoption through a synthetic ONVIF camera
 - unauthenticated and authenticated RTSP adoption
 - incorrect camera-credential rejection

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -29,6 +29,9 @@ services:
       secondary:
         ipv4_address: 172.31.0.20
         gw_priority: 0
+      large:
+        ipv4_address: 172.29.0.20
+        gw_priority: 0
     read_only: true
     cap_drop: [ALL]
     security_opt: ["no-new-privileges:true"]
@@ -130,6 +133,26 @@ services:
     healthcheck:
       disable: true
 
+  camera-onvif-large:
+    image: camadmiral-e2e:local
+    entrypoint: ["python", "/e2e/fake_onvif.py"]
+    environment:
+      ONVIF_ADDRESS: 172.29.0.87
+      ONVIF_UUID: synthetic-onvif-large
+      ONVIF_NAME: Large Subnet ONVIF
+    volumes:
+      - ./fake_onvif.py:/e2e/fake_onvif.py:ro
+      - ./fixtures/camera-onvif.yaml:/e2e/camera-onvif.yaml:ro
+    networks:
+      large:
+        ipv4_address: 172.29.0.87
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    tmpfs: [/tmp]
+    healthcheck:
+      disable: true
+
   camera-secondary:
     image: camadmiral-e2e:local
     entrypoint: ["/usr/local/bin/go2rtc", "-config", "/e2e/camera-secondary.yaml"]
@@ -168,7 +191,7 @@ services:
     volumes:
       - .:/e2e:ro
       - e2e-state:/state
-    networks: [lab, secondary]
+    networks: [lab, secondary, large]
     environment:
       CAMADMIRAL_E2E_ADMIN_PASSWORD: synthetic-e2e-admin-password
     read_only: true
@@ -185,6 +208,10 @@ networks:
     ipam:
       config:
         - subnet: 172.31.0.0/24
+  large:
+    ipam:
+      config:
+        - subnet: 172.29.0.0/16
 
 volumes:
   camadmiral-data:

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -153,6 +153,21 @@ services:
     healthcheck:
       disable: true
 
+  camera-rtsp-large:
+    image: camadmiral-e2e:local
+    entrypoint: ["/usr/local/bin/go2rtc", "-config", "/e2e/camera-secondary.yaml"]
+    volumes:
+      - ./fixtures/camera-secondary.yaml:/e2e/camera-secondary.yaml:ro
+    networks:
+      large:
+        ipv4_address: 172.29.0.88
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    tmpfs: [/tmp]
+    healthcheck:
+      disable: true
+
   camera-secondary:
     image: camadmiral-e2e:local
     entrypoint: ["/usr/local/bin/go2rtc", "-config", "/e2e/camera-secondary.yaml"]

--- a/e2e/fake_onvif.py
+++ b/e2e/fake_onvif.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import http.server
+import os
 import signal
 import socket
 import subprocess
 import threading
+import urllib.parse
 
 
-ADDRESS = "172.30.0.13"
+ADDRESS = os.environ.get("ONVIF_ADDRESS", "172.30.0.13")
+CAMERA_UUID = os.environ.get("ONVIF_UUID", "synthetic-onvif-camera")
+CAMERA_NAME = os.environ.get("ONVIF_NAME", "Synthetic ONVIF")
+ONVIF_MULTICAST_GROUP = "239.255.255.250"
 DEVICE_URL = f"http://{ADDRESS}:8080/onvif/device_service"
 MEDIA_URL = f"http://{ADDRESS}:8080/onvif/media_service"
 SOAP_START = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"'
@@ -66,14 +71,21 @@ class Handler(http.server.BaseHTTPRequestHandler):
 def discovery_responder(stop: threading.Event) -> None:
     response = envelope(
         'xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery"',
-        '<d:ProbeMatches><d:ProbeMatch><a:EndpointReference><a:Address>urn:uuid:synthetic-onvif-camera</a:Address>'
+        f'<d:ProbeMatches><d:ProbeMatch><a:EndpointReference><a:Address>urn:uuid:{CAMERA_UUID}</a:Address>'
         '</a:EndpointReference><d:Types>dn:NetworkVideoTransmitter tds:Device</d:Types>'
-        '<d:Scopes>onvif://www.onvif.org/name/Synthetic%20ONVIF onvif://www.onvif.org/hardware/LabCam</d:Scopes>'
+        f'<d:Scopes>onvif://www.onvif.org/name/{urllib.parse.quote(CAMERA_NAME)} onvif://www.onvif.org/hardware/LabCam</d:Scopes>'
         f'<d:XAddrs>{DEVICE_URL}</d:XAddrs></d:ProbeMatch></d:ProbeMatches>',
     )
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as server:
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         server.bind(("0.0.0.0", 3702))
+        # Real ONVIF cameras join the WS-Discovery group; without membership the
+        # kernel drops multicast probes and only unicast probes are answered.
+        server.setsockopt(
+            socket.IPPROTO_IP,
+            socket.IP_ADD_MEMBERSHIP,
+            socket.inet_aton(ONVIF_MULTICAST_GROUP) + socket.inet_aton(ADDRESS),
+        )
         server.settimeout(0.5)
         while not stop.is_set():
             try:

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -67,8 +67,13 @@ def main() -> int:
         run(
             "up", "--detach", "camadmiral", "camera-open", "camera-auth",
             "camera-onvif", "camera-secondary", "camera-onvif-large",
+            "camera-rtsp-large",
         )
         scenario("multi-subnet-discovery")
+        run(
+            "exec", "-T", "camadmiral", "python", "-c",
+            "import socket; socket.create_connection(('172.29.0.88', 554), 2).close()",
+        )
         scenario("large-subnet-multicast-discovery")
         run("down", "--volumes", "--remove-orphans")
         run(

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -66,9 +66,10 @@ def main() -> int:
         run("build", "camadmiral")
         run(
             "up", "--detach", "camadmiral", "camera-open", "camera-auth",
-            "camera-onvif", "camera-secondary",
+            "camera-onvif", "camera-secondary", "camera-onvif-large",
         )
         scenario("multi-subnet-discovery")
+        scenario("large-subnet-multicast-discovery")
         run("down", "--volumes", "--remove-orphans")
         run(
             "up", "--detach", "camadmiral", "camera-open", "camera-auth",

--- a/e2e/scenarios.py
+++ b/e2e/scenarios.py
@@ -707,14 +707,14 @@ def large_subnet_multicast_discovery() -> None:
     if not scan_id:
         raise ScenarioFailure("Full discovery did not return a scan identity")
 
-    def large_camera_found() -> dict[str, object] | None:
+    def large_cameras_found() -> dict[str, object] | None:
         state = discovery()
         if (
             state.get("scan_id") != scan_id
             or state.get("status") in {"queued", "running"}
         ):
             return None
-        camera = next(
+        onvif_camera = next(
             (
                 device
                 for device in state.get("devices", [])
@@ -722,28 +722,39 @@ def large_subnet_multicast_discovery() -> None:
             ),
             None,
         )
-        return state if camera else None
+        rtsp_camera = next(
+            (
+                device
+                for device in state.get("devices", [])
+                if device.get("ip") == "172.29.0.88" and device.get("rtsp")
+            ),
+            None,
+        )
+        return state if onvif_camera and rtsp_camera else None
 
     scanned = wait_for(
-        "multicast-only ONVIF discovery on an oversized subnet",
-        large_camera_found,
+        "multicast ONVIF and learned-neighbor RTSP discovery on an oversized subnet",
+        large_cameras_found,
         timeout=90,
     )
     raw_log = "\n".join(str(line) for line in scanned.get("raw_log", []))
     if "subnet 172.29.0.0/16 exceeds the" not in raw_log:
         raise ScenarioFailure("Full discovery did not report the oversized-subnet sweep skip")
-    if "unicast fallback skipped" not in raw_log:
-        raise ScenarioFailure("Oversized subnet did not skip the ONVIF unicast fallback")
-    if "RTSP port sweep skipped" not in raw_log:
-        raise ScenarioFailure("Oversized subnet did not skip the RTSP port sweep")
-    if "sent unicast probe to 172.29." in raw_log:
-        raise ScenarioFailure("Oversized subnet was swept with unicast ONVIF probes")
+    if "learned neighbor" not in raw_log:
+        raise ScenarioFailure("Oversized subnet did not use its learned neighbor candidates")
+    if (
+        "RTSP: subnet 172.29.0.0/16" not in raw_log
+        or "learned neighbor(s) only" not in raw_log
+    ):
+        raise ScenarioFailure("Oversized subnet did not bound RTSP probing to learned neighbors")
+    if "sent unicast probe to 172.29.0.88:3702" not in raw_log:
+        raise ScenarioFailure("Oversized subnet did not reuse the learned RTSP neighbor for ONVIF")
     scanners = scanned.get("scanners", {})
     if scanners.get("onvif") != "complete" or scanners.get("rtsp") != "complete":
         raise ScenarioFailure(f"Unexpected scanner states after oversized-subnet scan: {scanners}")
     print(
-        "large-subnet-multicast-discovery: multicast-only ONVIF discovery passed on an "
-        "oversized /16 subnet with per-address sweeps skipped"
+        "large-subnet-multicast-discovery: multicast ONVIF and learned-neighbor RTSP "
+        "discovery passed on an oversized /16 subnet without a per-address sweep"
     )
 
 

--- a/e2e/scenarios.py
+++ b/e2e/scenarios.py
@@ -4,6 +4,7 @@ import base64
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 import time
@@ -680,6 +681,72 @@ def multi_subnet_discovery() -> None:
     print("multi-subnet-discovery: manual and full RTSP discovery passed on a non-default LAN")
 
 
+def large_subnet_multicast_discovery() -> None:
+    wait_for_health()
+
+    def responder_ready() -> bool:
+        # The fake camera answers any UDP datagram on its WS-Discovery port.
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.settimeout(1)
+            probe.sendto(b"ready?", ("172.29.0.87", 3702))
+            try:
+                payload, _sender = probe.recvfrom(65535)
+            except socket.timeout:
+                return False
+            return b"ProbeMatch" in payload
+
+    wait_for("oversized-subnet camera discovery responder readiness", responder_ready)
+
+    full_request = request_json(
+        "/internal/discovery/scan",
+        method="POST",
+        headers={"X-CamAdmiral-Action": "scan"},
+        expected=202,
+    )
+    scan_id = full_request.get("scan_id")
+    if not scan_id:
+        raise ScenarioFailure("Full discovery did not return a scan identity")
+
+    def large_camera_found() -> dict[str, object] | None:
+        state = discovery()
+        if (
+            state.get("scan_id") != scan_id
+            or state.get("status") in {"queued", "running"}
+        ):
+            return None
+        camera = next(
+            (
+                device
+                for device in state.get("devices", [])
+                if device.get("ip") == "172.29.0.87" and device.get("onvif")
+            ),
+            None,
+        )
+        return state if camera else None
+
+    scanned = wait_for(
+        "multicast-only ONVIF discovery on an oversized subnet",
+        large_camera_found,
+        timeout=90,
+    )
+    raw_log = "\n".join(str(line) for line in scanned.get("raw_log", []))
+    if "subnet 172.29.0.0/16 exceeds the" not in raw_log:
+        raise ScenarioFailure("Full discovery did not report the oversized-subnet sweep skip")
+    if "unicast fallback skipped" not in raw_log:
+        raise ScenarioFailure("Oversized subnet did not skip the ONVIF unicast fallback")
+    if "RTSP port sweep skipped" not in raw_log:
+        raise ScenarioFailure("Oversized subnet did not skip the RTSP port sweep")
+    if "sent unicast probe to 172.29." in raw_log:
+        raise ScenarioFailure("Oversized subnet was swept with unicast ONVIF probes")
+    scanners = scanned.get("scanners", {})
+    if scanners.get("onvif") != "complete" or scanners.get("rtsp") != "complete":
+        raise ScenarioFailure(f"Unexpected scanner states after oversized-subnet scan: {scanners}")
+    print(
+        "large-subnet-multicast-discovery: multicast-only ONVIF discovery passed on an "
+        "oversized /16 subnet with per-address sweeps skipped"
+    )
+
+
 def load_state() -> dict[str, object]:
     try:
         return json.loads(STATE_PATH.read_text(encoding="utf-8"))
@@ -1005,6 +1072,7 @@ def frigate() -> None:
 SCENARIOS = {
     "baseline": baseline,
     "multi-subnet-discovery": multi_subnet_discovery,
+    "large-subnet-multicast-discovery": large_subnet_multicast_discovery,
     "runtime-drift": runtime_drift,
     "runtime-recovery": runtime_recovery,
     "camera-outage": camera_outage,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,4 +1,5 @@
 import ipaddress
+import socket
 import threading
 import unittest
 from unittest.mock import patch
@@ -111,16 +112,92 @@ eth0 0028A8C0 00000000 0001 0 0 100 00FFFFFF 0 0 0
 
         self.assertEqual(interfaces, [default, secondary, other_lan])
 
-    def test_large_subnet_is_rejected(self) -> None:
+    def test_large_subnet_is_selected_for_multicast_only_discovery(self) -> None:
         candidate = discovery.LanInterface(
             name="eth0",
             address=ipaddress.IPv4Address("10.1.2.3"),
-            network=ipaddress.IPv4Network("10.0.0.0/8"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
         )
 
         with patch.object(discovery, "_interface_ipv4", return_value=candidate.address):
-            with self.assertRaisesRegex(RuntimeError, "safety limit"):
-                discovery.private_lan_interfaces(self.ROUTES, [candidate])
+            interfaces = discovery.private_lan_interfaces(self.ROUTES, [candidate])
+
+        self.assertEqual(interfaces, [candidate])
+        self.assertFalse(discovery.sweep_allowed(candidate.network))
+        self.assertTrue(discovery.sweep_allowed(ipaddress.IPv4Network("10.0.0.0/24")))
+
+    def test_rtsp_sweep_is_skipped_on_large_subnet(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.1.2.3"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+        lines: list[str] = []
+
+        with patch.object(discovery, "_probe_rtsp") as probe:
+            result = discovery.discover_rtsp(interface, lines.append)
+
+        self.assertEqual(result, [])
+        probe.assert_not_called()
+        self.assertTrue(any("sweep limit" in line for line in lines))
+
+
+class _FakeUdpSocket:
+    """Capture sendto destinations; recvfrom immediately times out."""
+
+    def __init__(self, *_args, **_kwargs):
+        self.destinations: list[tuple[str, int]] = []
+        _FakeUdpSocket.last = self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def setsockopt(self, *_args):
+        pass
+
+    def bind(self, _address):
+        pass
+
+    def settimeout(self, _value):
+        pass
+
+    def sendto(self, _payload, destination):
+        self.destinations.append(destination)
+
+    def recvfrom(self, _size):
+        raise socket.timeout
+
+
+class OnvifSweepFallbackTests(unittest.TestCase):
+    def _run(self, network: str) -> list[tuple[str, int]]:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.0.2"),
+            network=ipaddress.IPv4Network(network),
+        )
+        with patch.object(discovery.socket, "socket", _FakeUdpSocket):
+            discovery.discover_onvif(interface)
+        return _FakeUdpSocket.last.destinations
+
+    def test_small_subnet_sends_multicast_first_then_unicast_fallback(self) -> None:
+        destinations = self._run("10.0.0.0/29")
+
+        multicast = [d for d in destinations if d == discovery.ONVIF_MULTICAST]
+        unicast = [d for d in destinations if d != discovery.ONVIF_MULTICAST]
+        self.assertEqual(len(multicast), 4)
+        self.assertEqual(destinations[:4], multicast)
+        self.assertEqual(
+            sorted(d[0] for d in unicast),
+            ["10.0.0.1", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6"],
+        )
+
+    def test_large_subnet_uses_multicast_only(self) -> None:
+        destinations = self._run("10.0.0.0/16")
+
+        self.assertEqual(destinations, [discovery.ONVIF_MULTICAST] * 4)
 
 
 class ResultTests(unittest.TestCase):
@@ -197,6 +274,62 @@ class ResultTests(unittest.TestCase):
         self.assertTrue(
             any("subnet=192.168.10.0/24" in line for line in result["raw_log"])
         )
+
+    def test_full_scan_on_large_subnet_skips_rtsp_and_keeps_multicast_results(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.0.2"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+        camera = {
+            "ip": "10.0.3.20",
+            "endpoint_reference": "urn:uuid:camera-1",
+            "service_urls": ["http://10.0.3.20/onvif/device_service"],
+            "scopes": [],
+            "types": [],
+            "name": "Warehouse",
+            "model": None,
+        }
+        progress = []
+
+        with (
+            patch.object(discovery, "private_lan_interfaces", return_value=[interface]),
+            patch.object(discovery, "discover_onvif", return_value=[camera]),
+            patch.object(discovery, "discover_rtsp") as rtsp,
+            patch.object(discovery, "discover_reachable_known", return_value=[]),
+            patch.object(discovery, "read_arp_table", return_value={}),
+        ):
+            result = discovery.scan_lan(
+                progress=lambda scanner, state, _interface: progress.append((scanner, state))
+            )
+
+        rtsp.assert_not_called()
+        self.assertEqual(
+            result["scanners"],
+            {"onvif": "complete", "rtsp": "skipped", "reachability": "complete"},
+        )
+        self.assertEqual([device["ip"] for device in result["devices"]], ["10.0.3.20"])
+        self.assertIn(("rtsp", "skipped"), progress)
+        self.assertTrue(any("sweep limit" in line for line in result["raw_log"]))
+
+    def test_full_scan_fails_when_onvif_errors_and_rtsp_is_skipped(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.0.2"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+
+        with (
+            patch.object(discovery, "private_lan_interfaces", return_value=[interface]),
+            patch.object(discovery, "discover_onvif", side_effect=OSError("multicast failed")),
+            patch.object(discovery, "discover_rtsp") as rtsp,
+            patch.object(discovery, "discover_reachable_known", return_value=[]),
+            patch.object(discovery, "read_arp_table", return_value={}),
+        ):
+            with self.assertRaisesRegex(discovery.DiscoveryScanError, "no RTSP sweep"):
+                discovery.scan_lan()
+
+        rtsp.assert_not_called()
 
     def test_onvif_and_rtsp_scanners_run_in_parallel(self) -> None:
         interface = discovery.LanInterface(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -141,6 +141,25 @@ eth0 0028A8C0 00000000 0001 0 0 100 00FFFFFF 0 0 0
         probe.assert_not_called()
         self.assertTrue(any("sweep limit" in line for line in lines))
 
+    def test_learned_neighbors_are_filtered_to_the_interface_and_bounded(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.2.3"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+        entries = {
+            "not-an-address": "02:00:00:00:00:01",
+            "10.0.2.3": "02:00:00:00:00:02",
+            "10.0.2.20": "02:00:00:00:00:20",
+            "10.0.2.10": "02:00:00:00:00:10",
+            "192.168.1.20": "02:00:00:00:00:30",
+        }
+
+        with patch.object(discovery, "MAX_SCAN_HOSTS", 1):
+            addresses = discovery.learned_neighbor_addresses(interface, entries)
+
+        self.assertEqual(addresses, ["10.0.2.10"])
+
 
 class _FakeUdpSocket:
     """Capture sendto destinations; recvfrom immediately times out."""
@@ -198,6 +217,24 @@ class OnvifSweepFallbackTests(unittest.TestCase):
         destinations = self._run("10.0.0.0/16")
 
         self.assertEqual(destinations, [discovery.ONVIF_MULTICAST] * 4)
+
+    def test_large_subnet_uses_learned_neighbors_for_unicast_fallback(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.0.2"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+        with patch.object(discovery.socket, "socket", _FakeUdpSocket):
+            discovery.discover_onvif(
+                interface,
+                fallback_addresses=["10.0.3.20", "192.168.1.20"],
+            )
+
+        self.assertEqual(
+            _FakeUdpSocket.last.destinations,
+            [discovery.ONVIF_MULTICAST] * 4
+            + [("10.0.3.20", discovery.ONVIF_MULTICAST[1])],
+        )
 
 
 class ResultTests(unittest.TestCase):
@@ -312,6 +349,45 @@ class ResultTests(unittest.TestCase):
         self.assertIn(("rtsp", "skipped"), progress)
         self.assertTrue(any("sweep limit" in line for line in result["raw_log"]))
 
+    def test_full_scan_on_large_subnet_probes_learned_neighbors(self) -> None:
+        interface = discovery.LanInterface(
+            name="eth0",
+            address=ipaddress.IPv4Address("10.0.0.2"),
+            network=ipaddress.IPv4Network("10.0.0.0/16"),
+        )
+        arp_entries = {
+            "10.0.3.20": "02:00:00:00:00:20",
+            "192.168.1.20": "02:00:00:00:00:21",
+        }
+        rtsp_camera = {
+            "ip": "10.0.3.20",
+            "endpoints": [{"port": 554, "verified": True}],
+        }
+
+        with (
+            patch.object(discovery, "private_lan_interfaces", return_value=[interface]),
+            patch.object(discovery, "discover_onvif", return_value=[]) as onvif,
+            patch.object(discovery, "discover_rtsp") as full_rtsp,
+            patch.object(
+                discovery,
+                "discover_rtsp_neighbors",
+                return_value=[rtsp_camera],
+            ) as neighbor_rtsp,
+            patch.object(discovery, "discover_reachable_known", return_value=[]),
+            patch.object(discovery, "read_arp_table", return_value=arp_entries),
+        ):
+            result = discovery.scan_lan()
+
+        full_rtsp.assert_not_called()
+        onvif.assert_called_once_with(interface, unittest.mock.ANY, ["10.0.3.20"])
+        neighbor_rtsp.assert_called_once_with(
+            interface,
+            ["10.0.3.20"],
+            unittest.mock.ANY,
+        )
+        self.assertEqual(result["scanners"]["rtsp"], "complete")
+        self.assertEqual([device["ip"] for device in result["devices"]], ["10.0.3.20"])
+
     def test_full_scan_fails_when_onvif_errors_and_rtsp_is_skipped(self) -> None:
         interface = discovery.LanInterface(
             name="eth0",
@@ -340,7 +416,7 @@ class ResultTests(unittest.TestCase):
         barrier = threading.Barrier(2)
         progress = []
 
-        def onvif(_interface, _log=None):
+        def onvif(_interface, _log=None, _fallback_addresses=()):
             barrier.wait(timeout=1)
             return [{"ip": "192.168.10.20", "endpoint_reference": "uuid:test", "service_urls": [], "scopes": [], "types": [], "name": "Camera", "model": None}]
 


### PR DESCRIPTION
## Problem

On a large LAN such as a /16, network scan failed with the safety-limit error (`LAN subnet ... has 65534 hosts; safety limit is 1024`) before discovery ran, even though ONVIF WS-Discovery multicast does not depend on enumerating every address.

## Change

- Oversized private subnets are eligible scan interfaces. ONVIF WS-Discovery multicast always runs first.
- Small subnets retain the bounded per-address ONVIF fallback and RTSP sweep.
- On oversized subnets, CamAdmiral reuses up to `CAMADMIRAL_MAX_SCAN_HOSTS` valid addresses already present in the Linux ARP neighbor cache. Those learned neighbors receive the unicast ONVIF fallback and RTSP probes without sweeping the subnet.
- When no learned neighbors exist, the RTSP scanner reports `skipped` instead of failing. Explicit-address probes and targeted camera recovery continue to work on oversized subnets.
- The implementation keeps `cap_drop: ALL`; it does not require packet capture, raw sockets, broadcast ping, or new container privileges.

The neighbor cache is an opportunistic hint, not a complete inventory. An RTSP-only camera absent from that cache can still be added by explicit address. Multicast discovery remains limited to the attached multicast domain unless the network provides a discovery proxy or relay.

## Tests

- Unit tests cover multicast-first ordering, multicast-only fallback when no neighbors are known, filtering and bounding learned neighbors, targeted ONVIF fallback, RTSP candidate probing, skipped scanner state, and failure behavior.
- The isolated E2E lab includes an oversized `/16`, an ONVIF camera found by multicast, and an RTSP-only camera found from a deliberately seeded neighbor entry. It verifies that both are discovered without a per-address `/16` sweep.
- The complete unit, component, browser, and E2E release gate runs on this PR.
