### PR TITLE
Reuse tested commit for image publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,40 @@ permissions:
   contents: read
 
 jobs:
-  release-gate:
-    uses: ./.github/workflows/release-gate.yml
+  verify-release-gate:
+    name: Verify tested commit
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require a successful release gate for this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "release-gate.yml",
+                status: "success",
+                per_page: 100,
+              },
+            );
+            const match = runs.find(run => run.head_sha === context.sha);
+            if (!match) {
+              core.setFailed(
+                `Commit ${context.sha} has not passed the CamAdmiral release gate. ` +
+                "Run the release gate for this exact commit before publishing.",
+              );
+              return;
+            }
+            core.info(`Reusing successful release gate run ${match.id} for ${context.sha}.`);
 
   publish:
     name: Publish multi-architecture image
-    needs: release-gate
+    needs: verify-release-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             core.info(`Reusing successful release gate run ${match.id} for ${context.sha}.`);
 
   publish:
-    name: Publish multi-architecture image
+    name: Publish amd64 image
     needs: verify-release-gate
     runs-on: ubuntu-latest
     permissions:
@@ -62,7 +62,6 @@ jobs:
           fi
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -75,7 +74,7 @@ jobs:
         id: build
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/reefyai/reefy-camadmiral:${{ steps.release.outputs.version }}

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -32,6 +32,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn('workflow_id: "release-gate.yml"', publish)
         self.assertIn('status: "success"', publish)
         self.assertIn("needs: verify-release-gate", publish)
+        self.assertIn("platforms: linux/amd64", publish)
+        self.assertNotIn("linux/arm64", publish)
+        self.assertNotIn("docker/setup-qemu-action", publish)
         self.assertNotIn("uses: ./.github/workflows/release-gate.yml", publish)
         self.assertNotIn('tags: ["v*"]', gate)
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -22,12 +22,17 @@ class ReleaseMetadataTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
 
-    def test_tag_release_has_one_gate_owner(self) -> None:
+    def test_tag_release_reuses_the_exact_tested_commit(self) -> None:
         publish = (ROOT / ".github" / "workflows" / "release.yml").read_text()
         gate = (ROOT / ".github" / "workflows" / "release-gate.yml").read_text()
 
         self.assertIn('tags: ["v*"]', publish)
-        self.assertIn("uses: ./.github/workflows/release-gate.yml", publish)
+        self.assertIn("uses: actions/github-script@v7", publish)
+        self.assertIn("run.head_sha === context.sha", publish)
+        self.assertIn('workflow_id: "release-gate.yml"', publish)
+        self.assertIn('status: "success"', publish)
+        self.assertIn("needs: verify-release-gate", publish)
+        self.assertNotIn("uses: ./.github/workflows/release-gate.yml", publish)
         self.assertNotIn('tags: ["v*"]', gate)
 
     def test_e2e_snapshot_wait_allows_bounded_recovery(self) -> None:


### PR DESCRIPTION
## Summary
- require a successful CamAdmiral release-gate run for the exact tagged commit
- publish the image immediately after that verification instead of rerunning the ten-minute E2E suite
- fail closed when the tagged commit has not already passed the gate

This keeps the same release safety boundary while removing the duplicate PR-plus-tag E2E run.