### PR TITLE
Skip runtime gate for documentation-only changes

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -2,19 +2,66 @@ name: CamAdmiral release gate
 
 on:
   workflow_call:
+    inputs:
+      force_full:
+        description: Run the complete release gate regardless of changed paths
+        type: boolean
+        default: true
   pull_request:
   workflow_dispatch:
+    inputs:
+      force_full:
+        description: Run the complete release gate regardless of changed paths
+        type: boolean
+        default: true
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: camadmiral-release-gate-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  classify-changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.classify.outputs.runtime }}
+    steps:
+      - name: Decide whether runtime validation is required
+        id: classify
+        uses: actions/github-script@v7
+        env:
+          FORCE_FULL: ${{ inputs.force_full }}
+        with:
+          script: |
+            if (process.env.FORCE_FULL === "true" || context.eventName !== "pull_request") {
+              core.setOutput("runtime", "true");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const documentationPath = path => path === "README.md" || path.startsWith("docs/");
+            const documentationOnly = files.length > 0 && files.length < 3000 && files.every(file =>
+              documentationPath(file.filename) &&
+              (!file.previous_filename || documentationPath(file.previous_filename))
+            );
+            core.setOutput("runtime", documentationOnly ? "false" : "true");
+            core.info(documentationOnly
+              ? "Documentation-only change: skipping runtime validation."
+              : "Runtime-affecting or unknown change: running the complete release gate.");
+
   release-gate:
     name: Unit, component, and E2E
+    needs: classify-changes
+    if: needs.classify-changes.outputs.runtime == 'true'
     # Never execute code from a fork on Reefy's persistent infrastructure.
     # Trusted branches use the large runner so Docker and browser caches are
     # retained between release-gate runs.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -45,6 +45,17 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn('["ubuntu-latest"]', gate)
         self.assertNotIn('tags: ["v*"]', gate)
 
+    def test_release_gate_skips_runtime_work_only_for_documentation(self) -> None:
+        gate = (ROOT / ".github" / "workflows" / "release-gate.yml").read_text()
+
+        self.assertIn("Classify changes", gate)
+        self.assertIn('path === "README.md" || path.startsWith("docs/")', gate)
+        self.assertIn("files.length < 3000", gate)
+        self.assertIn("file.previous_filename", gate)
+        self.assertIn("needs: classify-changes", gate)
+        self.assertIn("needs.classify-changes.outputs.runtime == 'true'", gate)
+        self.assertNotIn("paths-ignore:", gate)
+
     def test_e2e_snapshot_wait_allows_bounded_recovery(self) -> None:
         scenarios = (ROOT / "e2e" / "scenarios.py").read_text()
 


### PR DESCRIPTION
## Summary
- classify pull request files before scheduling runtime validation
- skip unit, Docker, Frigate, and browser E2E work only when every change is in README.md or docs/**
- run the complete gate for workflow calls, manual runs, renames from non-doc paths, large diffs, and unknown paths
- retain the existing required check as a successful skipped job for docs-only pull requests

## Validation
- release workflow regression tests passed
- workflow YAML parsed successfully
- full release gate required for this workflow-changing pull request