### PR TITLE
Add Docker-only quick start launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,24 @@ use ONVIF multicast plus addresses already learned in the host ARP table, avoidi
 unbounded sweep. Results are merged by IP and MAC. Adopted cameras are retained when absent,
 marked offline, and recovered after IP changes using ONVIF identity or a unique MAC.
 
-**Add camera** probes one explicit address without scanning the rest of the LAN. Detailed,
-timestamped protocol logs are available under scan details.
+If automatic discovery misses a camera, **Add camera** accepts its IP address or complete
+RTSP URL and probes only that address. The camera must be on a connected private LAN.
+Timestamped protocol logs are available under scan details.
 
 ![CamAdmiral ONVIF and RTSP network scan details](docs/images/camadmiral-network-scan.png)
 
-Adoption validates the credentials and discovered streams before storing anything. ONVIF
-cameras expose their media profiles directly; RTSP-only cameras use the compatibility
-database to find working paths without asking the operator to construct URLs manually.
+**Camera not detected?** If you identify the cause, please open a PR with the fix and a
+regression test.
+
+### Camera adoption
+
+To make a camera managed by CamAdmiral, select **Adopt** and provide credentials for the
+camera. CamAdmiral validates the credentials and streams before storing them. ONVIF cameras
+provide their media profiles directly; RTSP-only cameras use the compatibility database or
+an exact RTSP URL.
+
+CamAdmiral does not change the camera configuration. It only reads camera capabilities and
+consumes its media streams.
 
 ![CamAdmiral camera adoption dialog](docs/images/camadmiral-adopt-camera.png)
 
@@ -90,46 +100,36 @@ phones. No separate mobile app is required.
 
 ## Run with Docker
 
-Build the image and create one named volume for all persistent CamAdmiral state:
+### Quick start
+
+On a Linux system with Docker, run:
 
 ```console
-docker build -t camadmiral:latest .
-docker volume create camadmiral-data
-mkdir -p secrets
-openssl rand -hex 32 > secrets/api-token
-openssl rand -base64 24 > secrets/admin-password
-chmod 600 secrets/api-token secrets/admin-password
-docker run -d \
-  --name camadmiral \
-  --network host \
-  --restart unless-stopped \
-  --volume camadmiral-data:/var/lib/camadmiral \
-  --mount type=bind,source="$(pwd)/secrets/api-token",target=/run/secrets/camadmiral_api_token,readonly \
-  --mount type=bind,source="$(pwd)/secrets/admin-password",target=/run/secrets/camadmiral_admin_password,readonly \
-  camadmiral:latest
+./start-camadmiral.sh
 ```
 
-Open `http://<device-address>:18080`. No configuration file is required. On first boot,
-CamAdmiral generates its master key inside the data volume. Recreating the container with
-the same named volume preserves adopted cameras and credentials. Sign in as `admin` with
-the password in `secrets/admin-password`.
+The script pulls the latest image, creates the data volume, generates missing secrets, and
+starts one hardened container. It never replaces existing secrets or persistent data. The
+URL, admin credentials, and consumer API token are printed after startup. Secrets remain
+inside the `camadmiral-data` volume.
 
-For Docker Compose, create the API token once and start the checked-in hardened
-configuration:
+### Build and run from source
+
+To build the current source and start it through the same launcher:
 
 ```console
-mkdir -p secrets
-openssl rand -hex 32 > secrets/api-token
-openssl rand -base64 24 > secrets/admin-password
-chmod 600 secrets/api-token
-chmod 600 secrets/admin-password
-docker compose up -d
+docker build -t camadmiral:local .
+CAMADMIRAL_IMAGE=camadmiral:local ./start-camadmiral.sh
 ```
 
-The browser prompts for HTTP Basic credentials. Use username `admin` and the
-value stored in `secrets/admin-password`. Put CamAdmiral behind an HTTPS reverse
-proxy before accessing it across an untrusted network because HTTP Basic
-credentials are not encrypted by the application protocol.
+No configuration file is required. On first boot, CamAdmiral generates its master key inside
+the data volume. Recreating the container with the same named volume preserves adopted
+cameras and credentials. The launcher is a plain shell script containing the complete
+`docker volume` and `docker run` commands.
+
+The browser prompts for the printed HTTP Basic credentials. Put CamAdmiral behind an HTTPS
+reverse proxy before accessing it across an untrusted network because HTTP Basic credentials
+are not encrypted by the application protocol.
 
 The complete persistent state boundary is `/var/lib/camadmiral`. Back up and restore that
 volume as a unit. Stop CamAdmiral before making a raw volume copy so the SQLite database and
@@ -160,6 +160,8 @@ by the settings API. Alert messages contain only the camera name, incident state
 observation time. They do not contain camera credentials, media URLs, IP addresses, or MAC
 addresses.
 
+**Need another notification service?** Please open a PR with the provider.
+
 ## Frigate integration
 
 Open **Settings > Integrations** and add the loopback URL for each local Frigate API, such as
@@ -175,6 +177,8 @@ removed or changed by full sync.
 Frigate integrations are operational settings stored in CamAdmiral's SQLite database.
 They are included in the `/var/lib/camadmiral` backup boundary and are managed exclusively
 through the web UI, not the YAML process configuration.
+
+**Need another downstream consumer?** Please open a PR with the integration.
 
 ## Tests
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,6 +6,8 @@ CamAdmiral application modules.
 
 The isolated Docker Compose lab covers:
 
+- standalone Docker-only launcher startup, generated admin credentials, live HTTP access,
+  hardened runtime settings, and safe repeated execution
 - manual and full RTSP discovery on a non-default connected private subnet
 - multicast ONVIF discovery plus bounded learned-neighbor ONVIF and RTSP
   probing on an oversized /16 subnet without a per-address sweep

--- a/e2e/launcher.py
+++ b/e2e/launcher.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTAINER = "camadmiral"
+VOLUME = "camadmiral-data"
+URL = "http://127.0.0.1:18080"
+
+
+def docker(*arguments: str, check: bool = True, capture: bool = False) -> str:
+    completed = subprocess.run(
+        ["docker", *arguments],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+        stderr=subprocess.PIPE if capture else subprocess.DEVNULL,
+    )
+    return completed.stdout.strip() if completed.stdout else ""
+
+
+def exists(kind: str, name: str) -> bool:
+    return subprocess.run(
+        ["docker", kind, "inspect", name],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def wait_for_health(password: str, timeout: float = 45) -> dict[str, object]:
+    encoded = base64.b64encode(f"admin:{password}".encode()).decode()
+    request = urllib.request.Request(
+        f"{URL}/healthz",
+        headers={"Authorization": f"Basic {encoded}"},
+    )
+    deadline = time.monotonic() + timeout
+    last_error = "no response"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(request, timeout=2) as response:
+                return json.loads(response.read())
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            last_error = str(exc)
+            time.sleep(1)
+    raise RuntimeError(f"Launcher URL did not become healthy: {last_error}")
+
+
+def run_launcher() -> None:
+    if exists("container", CONTAINER) or exists("volume", VOLUME):
+        raise RuntimeError("Standalone launcher E2E resource already exists")
+    try:
+        with tempfile.TemporaryDirectory(prefix="camadmiral-launcher-") as temporary:
+            directory = Path(temporary)
+            script = directory / "start-camadmiral.sh"
+            shutil.copy2(ROOT / "start-camadmiral.sh", script)
+            script.chmod(0o755)
+
+            first = subprocess.run(
+                [str(script)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            created_container = exists("container", CONTAINER)
+            created_volume = exists("volume", VOLUME)
+            if not created_container or not created_volume:
+                raise RuntimeError("Launcher did not create its container and data volume")
+            if URL not in first.stdout or "Username: admin" not in first.stdout:
+                raise RuntimeError("Launcher did not print its URL and admin username")
+
+            password_lines = [
+                line.removeprefix("Password: ")
+                for line in first.stdout.splitlines()
+                if line.startswith("Password: ")
+            ]
+            password = password_lines[0] if len(password_lines) == 1 else ""
+            if not password or f"Password: {password}" not in first.stdout:
+                raise RuntimeError("Launcher did not print its generated admin password")
+            health = wait_for_health(password)
+            if not health.get("version"):
+                raise RuntimeError("Launcher health response did not include an app version")
+
+            container_before = docker("inspect", "--format", "{{.Id}}", CONTAINER, capture=True)
+            second = subprocess.run(
+                [str(script)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            container_after = docker("inspect", "--format", "{{.Id}}", CONTAINER, capture=True)
+            if container_before != container_after:
+                raise RuntimeError("Launcher replaced its existing container")
+            if f"Password: {password}" not in second.stdout:
+                raise RuntimeError("Launcher replaced its existing admin password")
+
+            host_config = json.loads(
+                docker("inspect", "--format", "{{json .HostConfig}}", CONTAINER, capture=True)
+            )
+            if not host_config.get("ReadonlyRootfs"):
+                raise RuntimeError("Launcher container root filesystem is writable")
+            if host_config.get("NetworkMode") != "host":
+                raise RuntimeError("Launcher container is not using host networking")
+            if host_config.get("RestartPolicy", {}).get("Name") != "unless-stopped":
+                raise RuntimeError("Launcher container restart policy is incorrect")
+    finally:
+        if exists("container", CONTAINER):
+            docker("rm", "--force", CONTAINER, check=False)
+        if exists("volume", VOLUME):
+            docker("volume", "rm", "--force", VOLUME, check=False)

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -6,6 +6,8 @@ import sys
 import time
 from pathlib import Path
 
+from launcher import run_launcher
+
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_FILE = ROOT / "e2e" / "compose.yaml"
@@ -147,6 +149,8 @@ def main() -> int:
         run("up", "--detach", "camera-auth-rotated")
         scenario("rotated-camera-ready")
         scenario("credential-repair")
+        run("down", "--volumes", "--remove-orphans")
+        run_launcher()
     except (OSError, subprocess.CalledProcessError, RuntimeError) as exc:
         print(f"CamAdmiral E2E failed: {exc}", file=sys.stderr)
         try:

--- a/start-camadmiral.sh
+++ b/start-camadmiral.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -eu
+
+DEFAULT_IMAGE="ghcr.io/reefyai/reefy-camadmiral:latest"
+IMAGE=${CAMADMIRAL_IMAGE:-$DEFAULT_IMAGE}
+CONTAINER="camadmiral"
+VOLUME="camadmiral-data"
+ADMIN_PASSWORD_FILE="/var/lib/camadmiral/standalone-secrets/admin-password"
+API_TOKEN_FILE="/var/lib/camadmiral/standalone-secrets/api-token"
+CONFIG_FILE="/var/lib/camadmiral/standalone.yaml"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required." >&2
+    exit 1
+fi
+
+show_access() {
+    password=$(docker exec "$CONTAINER" cat "$ADMIN_PASSWORD_FILE")
+    api_token=$(docker exec "$CONTAINER" cat "$API_TOKEN_FILE")
+    echo "CamAdmiral is running at http://127.0.0.1:18080"
+    echo "Use the device address instead of 127.0.0.1 from another computer."
+    echo "Username: admin"
+    echo "Password: $password"
+    echo "Consumer API token: $api_token"
+}
+
+if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
+    docker start "$CONTAINER" >/dev/null
+    show_access
+    exit 0
+fi
+
+if [ -z "${CAMADMIRAL_IMAGE:-}" ]; then
+    docker pull "$IMAGE"
+elif ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "CamAdmiral image not found: $IMAGE" >&2
+    exit 1
+fi
+
+docker volume create "$VOLUME" >/dev/null
+docker run --rm \
+    --volume "$VOLUME:/var/lib/camadmiral" \
+    --entrypoint python \
+    "$IMAGE" \
+    -c 'from pathlib import Path; import secrets
+root = Path("/var/lib/camadmiral/standalone-secrets")
+root.mkdir(mode=0o700, exist_ok=True)
+root.chmod(0o700)
+values = {
+    root / "api-token": secrets.token_hex(32),
+    root / "admin-password": secrets.token_urlsafe(24),
+}
+for path, value in values.items():
+    if not path.exists():
+        path.write_text(value + "\n", encoding="utf-8")
+        path.chmod(0o600)
+    elif not path.read_text(encoding="utf-8").strip():
+        raise SystemExit(f"existing secret is empty: {path.name}")
+config = Path("/var/lib/camadmiral/standalone.yaml")
+if not config.exists():
+    config.write_text("""version: 1
+secrets:
+  api_token_file: /var/lib/camadmiral/standalone-secrets/api-token
+  admin_password_file: /var/lib/camadmiral/standalone-secrets/admin-password
+""", encoding="utf-8")
+    config.chmod(0o600)'
+
+docker run -d \
+    --name "$CONTAINER" \
+    --network host \
+    --restart unless-stopped \
+    --read-only \
+    --cap-drop ALL \
+    --security-opt no-new-privileges:true \
+    --memory 256m \
+    --memory-swap 512m \
+    --pids-limit 192 \
+    --env "CAMADMIRAL_CONFIG_FILE=$CONFIG_FILE" \
+    --volume "$VOLUME:/var/lib/camadmiral" \
+    --tmpfs /run/camadmiral:rw,noexec,nosuid,size=4m,uid=10001,gid=10001 \
+    --tmpfs /tmp:rw,noexec,nosuid,size=16m,uid=10001,gid=10001 \
+    "$IMAGE" >/dev/null
+
+show_access

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -56,6 +56,17 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("needs.classify-changes.outputs.runtime == 'true'", gate)
         self.assertNotIn("paths-ignore:", gate)
 
+    def test_e2e_runs_the_docker_only_launcher(self) -> None:
+        runner = (ROOT / "e2e" / "run.py").read_text()
+        launcher = (ROOT / "e2e" / "launcher.py").read_text()
+
+        self.assertIn("from launcher import run_launcher", runner)
+        self.assertIn("run_launcher()", runner)
+        self.assertIn('URL = "http://127.0.0.1:18080"', launcher)
+        self.assertIn('f"admin:{password}"', launcher)
+        self.assertIn('host_config.get("ReadonlyRootfs")', launcher)
+        self.assertIn("Launcher replaced its existing admin password", launcher)
+
     def test_e2e_snapshot_wait_allows_bounded_recovery(self) -> None:
         scenarios = (ROOT / "e2e" / "scenarios.py").read_text()
 

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "start-camadmiral.sh"
+
+
+class StartScriptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.script = self.root / SCRIPT.name
+        shutil.copy2(SCRIPT, self.script)
+        self.script.chmod(0o755)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "docker.log"
+        docker = self.bin / "docker"
+        docker.write_text(
+            """#!/bin/sh
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+if [ "$1" = container ] && [ "$2" = inspect ]; then
+    [ "${DOCKER_CONTAINER_EXISTS:-0}" = 1 ] && exit 0
+    exit 1
+fi
+if [ "$1" = exec ]; then
+    case "$*" in
+        *admin-password) printf '%s\\n' generated-admin-password ;;
+        *) printf '%s\\n' generated-api-token ;;
+    esac
+fi
+exit 0
+""",
+            encoding="utf-8",
+        )
+        docker.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_script(self, *, container_exists: bool = False) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["PATH"] = f"{self.bin}:{environment['PATH']}"
+        environment["DOCKER_LOG"] = str(self.log)
+        environment["DOCKER_CONTAINER_EXISTS"] = "1" if container_exists else "0"
+        return subprocess.run(
+            [str(self.script)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+    def test_generates_secrets_and_runs_one_hardened_container(self) -> None:
+        completed = self.run_script()
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("pull ghcr.io/reefyai/reefy-camadmiral:latest", calls)
+        self.assertIn("volume create camadmiral-data", calls)
+        self.assertIn("run --rm --volume camadmiral-data:/var/lib/camadmiral", calls)
+        self.assertIn("run -d --name camadmiral --network host", calls)
+        self.assertIn("--read-only --cap-drop ALL", calls)
+        self.assertIn("--security-opt no-new-privileges:true", calls)
+        self.assertIn("CAMADMIRAL_CONFIG_FILE=/var/lib/camadmiral/standalone.yaml", calls)
+        self.assertNotIn("type=bind", calls)
+        self.assertNotIn("compose", calls)
+        self.assertIn("CamAdmiral is running at http://127.0.0.1:18080", completed.stdout)
+        self.assertIn("Username: admin", completed.stdout)
+        self.assertIn("Password: generated-admin-password", completed.stdout)
+
+    def test_existing_container_is_started_without_reinitializing_state(self) -> None:
+        completed = self.run_script(container_exists=True)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("start camadmiral", calls)
+        self.assertNotIn("pull ", calls)
+        self.assertNotIn("volume create", calls)
+        self.assertNotIn("run --rm", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a root-level Docker-only launcher that creates one persistent volume, generates secrets once, and starts one hardened CamAdmiral container
- simplify installation docs and clarify camera adoption and contribution paths
- add unit coverage plus a real Docker E2E scenario for startup, printed credentials, authenticated health access, runtime hardening, and safe repeated execution

## Validation
- 264 unit and component tests pass
- shell syntax and diff checks pass
- full Docker E2E runs in the release gate