### PR TITLE
Add safe CamAdmiral stop launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ starts one hardened container. It never replaces existing secrets or persistent 
 URL, admin credentials, and consumer API token are printed after startup. Secrets remain
 inside the `camadmiral-data` volume.
 
+Stop CamAdmiral without removing its container, credentials, or data:
+
+```console
+./stop-camadmiral.sh
+```
+
+Run `./start-camadmiral.sh` again to restart the preserved installation.
+
 ### Build and run from source
 
 To build the current source and start it through the same launcher:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,8 +6,8 @@ CamAdmiral application modules.
 
 The isolated Docker Compose lab covers:
 
-- standalone Docker-only launcher startup, generated admin credentials, live HTTP access,
-  hardened runtime settings, and safe repeated execution
+- standalone Docker-only launcher startup and shutdown, generated admin credentials, live
+  HTTP access, hardened runtime settings, safe repeated execution, and state-preserving restart
 - manual and full RTSP discovery on a non-default connected private subnet
 - multicast ONVIF discovery plus bounded learned-neighbor ONVIF and RTSP
   probing on an oversized /16 subnet without a per-address sweep

--- a/e2e/launcher.py
+++ b/e2e/launcher.py
@@ -64,6 +64,9 @@ def run_launcher() -> None:
             script = directory / "start-camadmiral.sh"
             shutil.copy2(ROOT / "start-camadmiral.sh", script)
             script.chmod(0o755)
+            stop_script = directory / "stop-camadmiral.sh"
+            shutil.copy2(ROOT / "stop-camadmiral.sh", stop_script)
+            stop_script.chmod(0o755)
 
             first = subprocess.run(
                 [str(script)],
@@ -112,6 +115,43 @@ def run_launcher() -> None:
                 raise RuntimeError("Launcher container is not using host networking")
             if host_config.get("RestartPolicy", {}).get("Name") != "unless-stopped":
                 raise RuntimeError("Launcher container restart policy is incorrect")
+
+            stopped = subprocess.run(
+                [str(stop_script)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            running = docker(
+                "container",
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
+                CONTAINER,
+                capture=True,
+            )
+            if running != "false":
+                raise RuntimeError("Stop launcher did not stop CamAdmiral")
+            if "camadmiral-data volume are preserved" not in stopped.stdout:
+                raise RuntimeError("Stop launcher did not explain that state was preserved")
+            if not exists("volume", VOLUME):
+                raise RuntimeError("Stop launcher removed the CamAdmiral data volume")
+
+            restarted = subprocess.run(
+                [str(script)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            restarted_container = docker(
+                "inspect", "--format", "{{.Id}}", CONTAINER, capture=True
+            )
+            if restarted_container != container_before:
+                raise RuntimeError("Restart replaced the existing CamAdmiral container")
+            if f"Password: {password}" not in restarted.stdout:
+                raise RuntimeError("Restart replaced the existing admin password")
+            if not wait_for_health(password).get("version"):
+                raise RuntimeError("Restarted launcher did not become healthy")
     finally:
         if exists("container", CONTAINER):
             docker("rm", "--force", CONTAINER, check=False)

--- a/stop-camadmiral.sh
+++ b/stop-camadmiral.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+CONTAINER="camadmiral"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required." >&2
+    exit 1
+fi
+
+if ! docker container inspect "$CONTAINER" >/dev/null 2>&1; then
+    echo "CamAdmiral is not installed. Nothing to stop."
+    exit 0
+fi
+
+running=$(docker container inspect --format '{{.State.Running}}' "$CONTAINER")
+if [ "$running" = "true" ]; then
+    docker stop "$CONTAINER" >/dev/null
+    echo "CamAdmiral is stopped."
+else
+    echo "CamAdmiral is already stopped."
+fi
+
+echo "The container, credentials, configuration, and camadmiral-data volume are preserved."
+echo "Run ./start-camadmiral.sh to start CamAdmiral again."

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -66,6 +66,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn('f"admin:{password}"', launcher)
         self.assertIn('host_config.get("ReadonlyRootfs")', launcher)
         self.assertIn("Launcher replaced its existing admin password", launcher)
+        self.assertIn('ROOT / "stop-camadmiral.sh"', launcher)
+        self.assertIn("Stop launcher did not stop CamAdmiral", launcher)
+        self.assertIn("Restart replaced the existing admin password", launcher)
 
     def test_e2e_snapshot_wait_allows_bounded_recovery(self) -> None:
         scenarios = (ROOT / "e2e" / "scenarios.py").read_text()

--- a/tests/test_start_script.py
+++ b/tests/test_start_script.py
@@ -9,16 +9,20 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = ROOT / "start-camadmiral.sh"
+START_SCRIPT = ROOT / "start-camadmiral.sh"
+STOP_SCRIPT = ROOT / "stop-camadmiral.sh"
 
 
-class StartScriptTests(unittest.TestCase):
+class LauncherScriptTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
-        self.script = self.root / SCRIPT.name
-        shutil.copy2(SCRIPT, self.script)
-        self.script.chmod(0o755)
+        self.start_script = self.root / START_SCRIPT.name
+        shutil.copy2(START_SCRIPT, self.start_script)
+        self.start_script.chmod(0o755)
+        self.stop_script = self.root / STOP_SCRIPT.name
+        shutil.copy2(STOP_SCRIPT, self.stop_script)
+        self.stop_script.chmod(0o755)
         self.bin = self.root / "bin"
         self.bin.mkdir()
         self.log = self.root / "docker.log"
@@ -27,8 +31,11 @@ class StartScriptTests(unittest.TestCase):
             """#!/bin/sh
 printf '%s\\n' "$*" >> "$DOCKER_LOG"
 if [ "$1" = container ] && [ "$2" = inspect ]; then
-    [ "${DOCKER_CONTAINER_EXISTS:-0}" = 1 ] && exit 0
-    exit 1
+    [ "${DOCKER_CONTAINER_EXISTS:-0}" = 1 ] || exit 1
+    case "$*" in
+        *State.Running*) printf '%s\n' "${DOCKER_CONTAINER_RUNNING:-true}" ;;
+    esac
+    exit 0
 fi
 if [ "$1" = exec ]; then
     case "$*" in
@@ -45,13 +52,20 @@ exit 0
     def tearDown(self) -> None:
         self.temporary.cleanup()
 
-    def run_script(self, *, container_exists: bool = False) -> subprocess.CompletedProcess[str]:
+    def run_script(
+        self,
+        script: Path,
+        *,
+        container_exists: bool = False,
+        container_running: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
         environment = os.environ.copy()
         environment["PATH"] = f"{self.bin}:{environment['PATH']}"
         environment["DOCKER_LOG"] = str(self.log)
         environment["DOCKER_CONTAINER_EXISTS"] = "1" if container_exists else "0"
+        environment["DOCKER_CONTAINER_RUNNING"] = "true" if container_running else "false"
         return subprocess.run(
-            [str(self.script)],
+            [str(script)],
             check=False,
             capture_output=True,
             text=True,
@@ -59,7 +73,7 @@ exit 0
         )
 
     def test_generates_secrets_and_runs_one_hardened_container(self) -> None:
-        completed = self.run_script()
+        completed = self.run_script(self.start_script)
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         calls = self.log.read_text(encoding="utf-8")
@@ -77,7 +91,7 @@ exit 0
         self.assertIn("Password: generated-admin-password", completed.stdout)
 
     def test_existing_container_is_started_without_reinitializing_state(self) -> None:
-        completed = self.run_script(container_exists=True)
+        completed = self.run_script(self.start_script, container_exists=True)
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         calls = self.log.read_text(encoding="utf-8")
@@ -85,6 +99,41 @@ exit 0
         self.assertNotIn("pull ", calls)
         self.assertNotIn("volume create", calls)
         self.assertNotIn("run --rm", calls)
+
+    def test_stop_preserves_the_container_and_data(self) -> None:
+        completed = self.run_script(
+            self.stop_script,
+            container_exists=True,
+            container_running=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("stop camadmiral", calls)
+        self.assertNotIn("rm ", calls)
+        self.assertIn("CamAdmiral is stopped.", completed.stdout)
+        self.assertIn("camadmiral-data volume are preserved", completed.stdout)
+        self.assertIn("./start-camadmiral.sh", completed.stdout)
+
+    def test_stop_is_idempotent_when_already_stopped(self) -> None:
+        completed = self.run_script(
+            self.stop_script,
+            container_exists=True,
+            container_running=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("stop camadmiral", calls)
+        self.assertIn("CamAdmiral is already stopped.", completed.stdout)
+
+    def test_stop_is_safe_when_camadmiral_is_not_installed(self) -> None:
+        completed = self.run_script(self.stop_script)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("stop camadmiral", calls)
+        self.assertIn("CamAdmiral is not installed. Nothing to stop.", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an idempotent Docker-only stop script that preserves the container, credentials, configuration, and data volume
- document stop and restart behavior next to the quick-start launcher
- extend unit and real Docker E2E coverage to verify shutdown, preserved state, restart, credentials, and container identity

## Validation
- 267 unit and component tests pass
- shell syntax and diff checks pass
- full Docker stop/restart scenario runs in the release gate